### PR TITLE
 Add User Search and Filtering by Email, Nickname/Username, and Role

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -173,6 +173,7 @@ async def list_users(
     limit: int = 10,
     email: Optional[str] = None,
     username: Optional[str] = None,
+    role: Optional[str] = None,
     db: AsyncSession = Depends(get_db),
     current_user: dict = Depends(require_role(["ADMIN", "MANAGER"]))
 ):

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -122,6 +122,9 @@ class UserService:
         if username:
             query = query.where(User.nickname.ilike(f"%{username}%"))
 
+        if role:
+            query = query.where(User.role == role)
+
         query = query.offset(skip).limit(limit)
     
         result = await cls._execute_query(session, query)


### PR DESCRIPTION
This Pull Request adds search and filtering functionality for the user management module. Administrators can now search users based on partial matches of their email, nickname/username and roles. Updates include changes to the /users/ endpoint and new unit tests verifying search behavior.

Minimum viable functionality for the "User Search and Filtering" feature is complete. All unit tests pass successfully