### PR TITLE
made secure password policy in UserCreate schema

### DIFF
--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -1,5 +1,5 @@
 from builtins import ValueError, any, bool, str
-from pydantic import BaseModel, EmailStr, Field, validator, root_validator
+from pydantic import BaseModel, EmailStr, Field, validator, root_validator, HttpUrl, constr
 from typing import Optional, List
 from datetime import datetime
 from enum import Enum
@@ -35,7 +35,15 @@ class UserBase(BaseModel):
 
 class UserCreate(UserBase):
     email: EmailStr = Field(..., example="john.doe@example.com")
-    password: str = Field(..., example="Secure*1234")
+    password: constr(
+        min_length=8,
+        regex=r"^(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*()_+=\-{}[\]:;\"'<>,.?/\\|]).+$"
+) = Field(
+    ..., 
+    example="Secure*1234", 
+    description="Must contain at least 8 characters, 1 uppercase letter, 1 digit, and 1 special character."
+)
+    profile_picture_url: Optional[HttpUrl] = None
 
 class UserUpdate(UserBase):
     email: Optional[EmailStr] = Field(None, example="john.doe@example.com")

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -218,3 +218,13 @@ async def test_invalid_profile_url_register(async_client):
     }
     response = await async_client.post("/register/", json=user_data)
     assert response.status_code == 422
+
+@pytest.mark.asyncio
+async def test_weak_password_rejected(async_client):
+    user_data = {
+        "email": "weakpassuser@example.com",
+        "password": "abc123",  # Weak password
+        "nickname": "weakuser"
+    }
+    response = await async_client.post("/register/", json=user_data)
+    assert response.status_code == 422  # Validation error


### PR DESCRIPTION
Closes #5 
This pull request enforces a strong password policy during user registration.
The password field in the UserCreate schema now requires:

- Minimum 8 characters

- At least one uppercase letter

- At least one digit

- At least one special character