### PR TITLE
generate nickname if missing during registration

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -59,10 +59,11 @@ class UserService:
                 return None
             validated_data['hashed_password'] = hash_password(validated_data.pop('password'))
             new_user = User(**validated_data)
-            new_nickname = generate_nickname()
-            while await cls.get_by_nickname(session, new_nickname):
+            if not validated_data.get("nickname"):
                 new_nickname = generate_nickname()
-            new_user.nickname = new_nickname
+                while await cls.get_by_nickname(session, new_nickname):
+                    new_nickname = generate_nickname()
+                validated_data["nickname"] = new_nickname
             logger.info(f"User Role: {new_user.role}")
             user_count = await cls.count(session)
             new_user.role = UserRole.ADMIN if user_count == 0 else UserRole.ANONYMOUS            

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -228,3 +228,14 @@ async def test_weak_password_rejected(async_client):
     }
     response = await async_client.post("/register/", json=user_data)
     assert response.status_code == 422  # Validation error
+
+@pytest.mark.asyncio
+async def test_register_user_without_nickname(async_client):
+    user_data = {
+        "email": "nonickname@example.com",
+        "password": "SecurePass123!"
+        # No nickname provided
+    }
+    response = await async_client.post("/register/", json=user_data)
+    assert response.status_code == 200
+    assert response.json()["nickname"] is not None


### PR DESCRIPTION
Fix #7 
Currently, when creating a new user, the nickname field is directly accepted from the request input without automatically generating a default nickname if the user leaves it blank. This can result in users having no nickname or manually entering invalid ones.

If a user registers without providing a nickname, it doesn't auto-generate one (even though generate_nickname() utility is available).

Nickname field should always have a unique value (generated if blank).