### PR TITLE
enforced every registered user must verify there email

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -71,6 +71,7 @@ class UserService:
 
             else:
                 new_user.verification_token = generate_verification_token()
+                await email_service.send_verification_email(new_user)
 
             session.add(new_user)
             await session.commit()

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -239,3 +239,13 @@ async def test_register_user_without_nickname(async_client):
     response = await async_client.post("/register/", json=user_data)
     assert response.status_code == 200
     assert response.json()["nickname"] is not None
+
+@pytest.mark.asyncio
+async def test_admin_registration_requires_email_verification(async_client):
+    response = await async_client.post("/register/", json={
+        "email": "newadmin@example.com",
+        "password": "StrongPass123!"
+    })
+    assert response.status_code == 200
+    user_data = response.json()
+    assert user_data.get("email_verified") is False or None


### PR DESCRIPTION
fix #12 
all registered users must verify their email address before being allowed to login. Improves security and standardizes user onboarding flow.